### PR TITLE
Fixes Hand of Justice localization + Initial deDE locale support

### DIFF
--- a/MikScrollingBattleText/MikScrollingBattleText-deDE.lua
+++ b/MikScrollingBattleText/MikScrollingBattleText-deDE.lua
@@ -1,6 +1,6 @@
 local L = AceLibrary("AceLocale-2.2"):new("MikScrollingBattleText")
 
-L:RegisterTranslations("enUS", function()
+L:RegisterTranslations("deDE", function()
     return {
 		["Debug mode has been enabled."] = true,
 		["Debug mode has been disabled."] = true,
@@ -8,10 +8,10 @@ L:RegisterTranslations("enUS", function()
 		["Event search mode has been disabled."] = true,
 		["The mod is now disabled."] = true,
 		["The mod is now enabled."] = true,
-		["Hits"] = true,
-		["Crit"] = true,
-		["Crits"] = true,
-		["Multiple"] = true,
+		["Hits"] = "Treffer",
+		["Crit"] = "Krit",
+		["Crits"] = "Krits",
+		["Multiple"] = "Mehrere",
 		[" (%d vulnerability)"] = true,
 		[" <\124cff00b37e\124h%d\124h\124r>"] = true,
 		["Profile Reset"] = true,
@@ -21,6 +21,6 @@ L:RegisterTranslations("enUS", function()
 		["Fire"] = true,
 		["Lava"] = true,
 		["Slime"] = true,
-        ["Hand of Justice"] = true,
+        ["Hand of Justice"] = "Hand der Gerechtigkeit",
     }
 end)

--- a/MikScrollingBattleText/MikScrollingBattleText-frFR.lua
+++ b/MikScrollingBattleText/MikScrollingBattleText-frFR.lua
@@ -21,5 +21,6 @@ L:RegisterTranslations("frFR", function()
 		["Fire"] = "Feu",
 		["Lava"] = "Lave",
 		["Slime"] = "Gelée",
+        ["Hand of Justice"] = "Main de justice",
     }
 end)

--- a/MikScrollingBattleText/MikScrollingBattleText.toc
+++ b/MikScrollingBattleText/MikScrollingBattleText.toc
@@ -1,5 +1,5 @@
 ## Interface: 11200
-## Version: 3.9
+## Version: 4.0.1
 ## Title: Mik's Scrolling Battle Text
 ## Notes: Scrolls battle information around the character model.
 ## OptionalDeps: SW_FixLogStrings
@@ -11,6 +11,7 @@ Libs\BabbleSpell-2.2\Babble-Spell-2.2.lua
 
 MikScrollingBattleText-enUS.lua
 MikScrollingBattleText-frFR.lua
+MikScrollingBattleText-deDE.lua
 
 localization.lua
 MikTableRecyclerObject.lua

--- a/MikScrollingBattleText/localization.lua
+++ b/MikScrollingBattleText/localization.lua
@@ -1024,7 +1024,7 @@ MikSBT.DEFAULT_CONFIG = {
   MSBT_TRIGGER_HAND_OF_JUSTICE = {
    EventSettings = {
     Show				= true,
-    Message				= BS["Hand of Justice"].."!",
+    Message				= L["Hand of Justice"].."!",
     IsSticky			= true,
     FontSettings = {
      Color				= {r=1, g=1, b=0},
@@ -1034,7 +1034,7 @@ MikSBT.DEFAULT_CONFIG = {
    TriggerSettings = {
     TriggerType			= 6,
     TriggerEvents			= {"CHAT_MSG_SPELL_SELF_BUFF"},
-    SearchPatterns		= {string.format(SPELLEXTRAATTACKSSELF, 1, BS["Hand of Justice"])}, --"Vous gagnez %d attaques supplémentaires grâce à Main de justice"
+    SearchPatterns		= {string.format(SPELLEXTRAATTACKSSELF, 1, L["Hand of Justice"])}, --"Vous gagnez %d attaques supplémentaires grâce à Main de justice"
    },
    Texture = "Interface\\Icons\\inv_jewelry_talisman_01"
   },


### PR DESCRIPTION
Adding Hand of Justice localization string inside BabbleSpell-2.2 was a bad idea - other addons load their bundled BabbleSpell-2.2 library before this gets loaded and you end up with LUA error that localization is missing.

On top of that, this error prevents localization.lua to properly load, breaking profile reset and profile init (when there are no savedvariables present).

These changes add localization in local localization file + add initial deDE locale support.
