### PR TITLE
Fixes for Chinese Client: Outgoing heals amount shown incorrectly and no Chinese character supporting font

### DIFF
--- a/MikScrollingBattleText/MikCombatEventHelper.lua
+++ b/MikScrollingBattleText/MikCombatEventHelper.lua
@@ -3314,7 +3314,11 @@ function MikCEH.GetGlobalStringInfo(globalStringName)
     -- Check for one of the types that need a string.
     elseif (string.find(currentChar, "[cEefgGiouXxqs]")) then
      -- Replace the format code with lua capture string syntax.
-     searchString = searchString .. "(.+)";
+     if GetLocale() == "zhCN" and globalStringName == "HEALEDSELFOTHER" then -- edge for outgoing heals on others case for zhCN client
+      searchString = searchString .. "([^0-9.]+)"
+     else
+      searchString = searchString .. "(.+)";
+     end
 
      -- Increment the argument number.
      argumentNumber = argumentNumber + 1;

--- a/MikScrollingBattleText/localization.lua
+++ b/MikScrollingBattleText/localization.lua
@@ -114,6 +114,7 @@ MikSBT.AVAILABLE_FONTS = {
  [28] = {Name="Myriad-Pro", Path="Interface\\Addons\\MikScrollingBattleText\\Fonts\\Myriad-Pro.ttf"},
  [29] = {Name="PT-Sans-Narrow-Bold", Path="Interface\\Addons\\MikScrollingBattleText\\Fonts\\PT-Sans-Narrow-Bold.ttf"},
  [30] = {Name="PT-Sans-Narrow-Regular", Path="Interface\\Addons\\MikScrollingBattleText\\Fonts\\PT-Sans-Narrow-Regular.ttf"},
+ [31] = {Name="Simhei", Path="Interface\\Addons\\MikScrollingBattleText\\Fonts\\simhei.ttf"},
 };
 
 -- Holds the available font outlines.


### PR DESCRIPTION
### Fixes edge case bug with Chinese client for outgoing heals, where it only shows the last digit of the heal amount:
![chinese_client_heal](https://user-images.githubusercontent.com/1865818/46493523-2988df00-c843-11e8-93df-799bda7a4fbd.png)
This is because the combat message on the chinese client doesn't have words between the target receiving the heal's name and the amount healed, so it included all but the last digits of the amount healed as the name of the target (as shown in the above screenshot). This is fixed by having the target name string regex match only non-digits for the `HEALEDSELFOTHER` event when using the zhCN client.

### Also on the zhCN client aura names were not being displayed for any of the fonts:
![chinese_client_adventure_font](https://user-images.githubusercontent.com/1865818/46493522-2988df00-c843-11e8-979c-07ab9fc4cc3d.png)

The new simhei font option supports simplified chinese characters so names of auras will be shown properly: 
![chinese_client_simhei_font](https://user-images.githubusercontent.com/1865818/46493801-dfecc400-c843-11e8-83ad-17887f33b37f.png)